### PR TITLE
Only use L::U and L::SU if required

### DIFF
--- a/t/01-basic.t
+++ b/t/01-basic.t
@@ -89,17 +89,6 @@ is_deeply(
     'Baz::test_apply returns expected list'
 );
 
-is(
-    ( List::AllUtils::first { $_ > 5 } ( 1, 2, 5, 22, 7 ) ),
-    22,
-    'explicitly calling List::AllUtils::first produces the correct result'
-);
-
-ok(
-    ( List::AllUtils::any { $_ > 5 } ( 1, 2, 5, 22, 7 ) ),
-    'explicitly calling List::AllUtils::any produces the correct result'
-);
-
 {
     package ImportsAllSub;
 

--- a/utils/check_for_updates.pl
+++ b/utils/check_for_updates.pl
@@ -1,0 +1,25 @@
+# help to check if AllUtils is missing anything
+
+use 5.10.0;
+
+use strict;
+use warnings;
+
+use List::AllUtils;
+use Module::Runtime qw/ use_module /;
+
+for my $module ( keys %List::AllUtils::ALL_EXPORTS ) {
+    use_module( $module );
+
+    say "## ", $module;
+
+    for my $function ( eval '@'.$module.'::EXPORT_OK' ) {
+        my $f = $List::AllUtils::EXPORTED_FUNCTIONS{$function} or do {
+            say "we're missing $function";
+            next;
+        };
+        my ($source) = keys %$f;
+        say "using $source\'s $function" if $source ne $module;
+    }
+
+}

--- a/utils/print_functions.pl
+++ b/utils/print_functions.pl
@@ -1,0 +1,7 @@
+use 5.10.0;
+
+use List::AllUtils qw/ pairmap sort_by /;
+
+say join ' ', @$_ 
+    for sort_by { $_->[0] } 
+        pairmap { [ $a => %$b ] } %List::AllUtils::EXPORTED_FUNCTIONS;


### PR DESCRIPTION
With this patch the underlying modules are use'd only
if we're importing any of their functions.

Also, we're keeping track of when the functions for introduced so
that if I do

        use List::AllUtils qw/ uniq /;

I'd get a

        "List::Util v0.34 required for 'uniq'"

if the local version of List::Util is too old.

Btw, this foreshadow my next PR, where I'll make List::UtilsBy
join the flock (which makes the load-on-demand more interesting)